### PR TITLE
Change dependency from 'AdMob' to 'Google-Mobile-Ads-SDK'

### DIFF
--- a/AdMobHelper.podspec
+++ b/AdMobHelper.podspec
@@ -8,5 +8,5 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/youknowone/AdMobHelper.git", :tag => "6.4.0" }
   s.platform     = :ios
   s.source_files = '*.{h,m}'
-  s.dependency 'AdMob'
+  s.dependency 'Google-Mobile-Ads-SDK'
 end


### PR DESCRIPTION
AdMob SDK was 'AdMob', but it's called 'Google-Mobile-Ads-SDK', so you should change podspec.

(Sorry for duplicated issues.)
